### PR TITLE
Make hp-wallpapers provide ubuntu-wallpapers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,6 @@ Vcs-Git: https://github.com/pop-os/hp-wallpapers.git
 
 Package: pop-hp-wallpapers
 Architecture: all
+Provides: ubuntu-wallpapers
 Description: Wallpapers for HP products
  A collection of wallpapers for HP products using Pop!_OS


### PR DESCRIPTION
Needed to satisfy gnome-shell dependency on ubuntu-wallpapers when pop-wallpapers is removed.

Should make https://github.com/pop-os/desktop/pull/84 work.